### PR TITLE
Fix redirect service link memoization

### DIFF
--- a/app/services/redirect_service.rb
+++ b/app/services/redirect_service.rb
@@ -12,9 +12,6 @@ class RedirectService
   attr_reader :token
 
   def link
-    if @link
-      return @link
-    end
-    Link.where(token: token).first || NoLink.new
+    @link ||= Link.where(token: token).first || NoLink.new
   end
 end


### PR DESCRIPTION
Summary
-------

While examining code coverage metrics, it seems that the memoization
inside the RedirectService object was not implemented correctly. The
"Link" value would never have been set, the condition to determine if
we've previously loaded the link would always fail, and we'd attempt
another lookup via ActiveRecord. This aims to fix all of that using
the mallot operator instead to assign the RedirectService's "Link".