### PR TITLE
Fix code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: ruby
 rvm:
   - 2.5.3
-addons:
-    code_climate:
-        repo_token: 6d4e6d5bcbecb8e6afc5c167d824b55dfe4faafa4822c9155e4339e4cea935b7
+env:
+  global:
+    - CC_TEST_REPORTER_ID=6d4e6d5bcbecb8e6afc5c167d824b55dfe4faafa4822c9155e4339e4cea935b7
 services:
   - postgresql
 before_install:
   - gem install bundler
 before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   - cp .env_example .env
   - psql -c 'create database srink_test;' -U postgres
   - bundle install
@@ -16,4 +19,4 @@ before_script:
 script:
   - bundle exec rspec
 after_success:
-  - bundle exec codeclimate-test-reporter
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ end
 
 group :test do
   gem "capybara"
-  gem "codeclimate-test-reporter"
   gem "factory_girl_rails", "~> 4.0"
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,8 +69,6 @@ GEM
       bcrypt
       email_validator (~> 1.4)
       rails (>= 3.1)
-    codeclimate-test-reporter (1.0.7)
-      simplecov
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -268,7 +266,6 @@ DEPENDENCIES
   byebug
   capybara
   clearance
-  codeclimate-test-reporter
   coffee-rails (~> 4.2)
   dotenv-rails
   factory_girl_rails (~> 4.0)


### PR DESCRIPTION
Summary
-------

Some time ago, CodeClimate changed the interface to report code
coverage metrics. The srink project never kept up with the changes. As
such we need to move away from the old codeclimate-test-reporter gem
in favor of using the stand-alone reporter in CI.

References
----------

- https://docs.codeclimate.com/docs/configuring-test-coverage#section-quick-guide
- https://docs.codeclimate.com/docs/travis-ci-test-coverage