### PR TITLE
Update bourbon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby "2.5.3"
 
+gem "autoprefixer"
 gem "bootsnap"
 gem "bourbon"
 gem "clearance"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     argon2 (2.0.2)
       ffi (~> 1.9)
       ffi-compiler (>= 0.1)
+    autoprefixer (0.0.1)
     bcrypt (3.1.16)
     bitters (1.0.0)
       bourbon (>= 3.2)
@@ -68,9 +69,8 @@ GEM
       thor
     bootsnap (1.3.2)
       msgpack (~> 1.0)
-    bourbon (4.2.7)
-      sass (~> 3.4)
-      thor (~> 0.19)
+    bourbon (7.0.0)
+      thor (~> 1.0)
     builder (3.2.4)
     byebug (5.0.0)
       columnize (= 0.9.0)
@@ -228,7 +228,11 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    sass (3.4.25)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (5.0.8)
       railties (>= 5.2.0)
       sass (~> 3.1)
@@ -260,7 +264,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.20.3)
+    thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     turbolinks (5.0.1)
@@ -292,6 +296,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  autoprefixer
   bitters
   bootsnap
   bourbon

--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -1,6 +1,6 @@
-#{$all-button-inputs},
+#{$all-buttons},
 button {
-  @include appearance(none);
+  appearance: none;
   -webkit-font-smoothing: antialiased;
   background-color: $action-color;
   border-radius: $base-border-radius;

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -57,7 +57,7 @@ textarea {
 }
 
 input[type="search"] {
-  @include appearance(none);
+  appearance: none;
 }
 
 input[type="checkbox"],

--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -1,5 +1,5 @@
 table {
-  @include font-feature-settings("kern", "liga", "tnum");
+  font-feature-settings: kern, liga, tnum;
   border-collapse: collapse;
   margin: $small-spacing 0;
   table-layout: fixed;

--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -1,5 +1,5 @@
 body {
-  @include font-feature-settings("kern", "liga", "pnum");
+  font-feature-settings: kern, liga, pnum;
   -webkit-font-smoothing: antialiased;
   color: $base-font-color;
   font-family: $base-font-family;

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$base-font-family: $helvetica;
+$base-font-family: $font-stack-helvetica ;
 $heading-font-family: $base-font-family;
 
 // Font Sizes


### PR DESCRIPTION
This is a prerequisite to continue the Rails 5.2 => 6.1 upgrade. In
order to get past rails 6.0, bourbon needs updated from 4.x => 7.x. The
bourbon 4.x => 5.x upgrade requires a bit of work since a number of
mixins were renamed or removed.