### PR TITLE
Update pg gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    pg (0.18.4)
+    pg (1.2.3)
     public_suffix (2.0.5)
     puma (5.2.2)
       nio4r (~> 2.0)


### PR DESCRIPTION
This is a prerequisite to continue the Rails 5.2 => 6.1 upgrade. In
order to get past rails 6.0, pg gem needs to be at  > 1.0